### PR TITLE
Implement Iterator

### DIFF
--- a/src/KeyedDB.ts
+++ b/src/KeyedDB.ts
@@ -232,4 +232,8 @@ export default class KeyedDB<T, K> implements IKeyedDB<T, K> {
     const valueKey = this.key.key(value)
     return binarySearch (this.array, v => this.key.compare(valueKey, this.key.key(v)))
   }
+
+  *[Symbol.iterator](): Iterator<T> {
+    for (let item of this.array) yield item
+  }
 }

--- a/src/Tests.ts
+++ b/src/Tests.ts
@@ -254,4 +254,14 @@ describe ('KeyedDB Test', () => {
             )
         )
     })
+    it('should iterate', () => {
+        const db = new KeyedDB (phoneCallKey)
+        data.forEach (v => db.insert(v))
+
+        const result = []
+        for (let item of db) {
+            result.push(item)
+        }
+        assert.deepStrictEqual (result, data)
+    })
 })

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -8,7 +8,7 @@ export type Comparable<ObjectType, KeyType> = {
 /** Identifier function for object */
 export type Identifiable<T> = (v: T) => string
 
-export interface IKeyedDB<T, K> {
+export interface IKeyedDB<T, K> extends Iterable<T> {
 
     length: number
     first: T


### PR DESCRIPTION
This enables the `KeyedDB` to be used as an Iterator in `for..of` loops without needing to call `KeyedDB.all()` first
```TS
const db = new KeyedDB(phoneCallKey)
data.forEach(v => db.insert(v))

const result = []
for (let item of db) 
        result.push(item)

assert.deepStrictEqual(result, data)
```